### PR TITLE
Update MySQL Connector version to v8

### DIFF
--- a/serverlist-server/pom.xml
+++ b/serverlist-server/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.17</version>
+            <version>8.0.19</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
 (which is still compatible with the v5.6 and v5.7 DB of MySQL)
This fixes also Issue #3 

I couldn't test this myself, the build environment I have is probably not correctly setup.
I will open a separate issue for this.