### PR TITLE
add Dockerfile to run headless on a Raspberry Pi

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM hypriot/rpi-java
+RUN mkdir /brc
+COPY BedrockConnect-1.0-SNAPSHOT.jar /brc
+WORKDIR /brc
+EXPOSE 19132/udp
+CMD ["java", "-Xms1G", "-Xmx1G", "-jar", "BedrockConnect-1.0-SNAPSHOT.jar", "nodb=true"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,7 @@
+# BedrockConnect on Docker on Raspberry Pi
+
+- Put the `Dockerfile` and the `BedrockConnect-1.0-SNAPSHOT.jar` in one directory
+- Configure the `CMD` line in the `Dockerfile` to fit your needs
+  - `generatedns` will not work, as it wants user input
+- run `docker build -t bedrock-connect .`
+- run `docker run --name "bedrock-c" -d --restart always -p 19132:19132/udp bedrock-connect`


### PR DESCRIPTION
# BedrockConnect on Docker on Raspberry Pi

- Put the `Dockerfile` and the `BedrockConnect-1.0-SNAPSHOT.jar` in one directory
- Configure the `CMD` line in the `Dockerfile` to fit your needs
  - `generatedns` will not work, as it wants user input
- run `docker build -t bedrock-connect .`
- run `docker run --name "bedrock-c" -d --restart always -p 19132:19132/udp bedrock-connect`
