### PR TITLE
Use a better alternative for CubeCraft's IP

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
@@ -952,7 +952,7 @@ public class PacketHandler implements BedrockPacketHandler {
                                             transfer("108.178.12.125", 19132);
                                             break;
                                         case 3: // Cubecraft
-                                            transfer("213.32.11.233", 19132);
+                                            transfer("play.cubecraft.net", 19132);
                                             break;
                                         case 4: // Lifeboat
                                             transfer("63.143.40.66", 19132);


### PR DESCRIPTION
Hardcoding this to a specific IP meant that all players using BedrockConnect were only on one of our proxies. `play.cubecraft.net` uses the same servers as `mco.cubecraft.net` so will load balance requests correctly.