### PR TITLE
Update to 1.16.100

### DIFF
--- a/serverlist-server/pom.xml
+++ b/serverlist-server/pom.xml
@@ -94,7 +94,7 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
-            <artifactId>bedrock-v408</artifactId>
+            <artifactId>bedrock-v419</artifactId>
             <version>2.6.0-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/PipePlayer.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/PipePlayer.java
@@ -11,6 +11,7 @@ import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockServerSession;
 import com.nukkitx.protocol.bedrock.data.*;
 import com.nukkitx.protocol.bedrock.data.inventory.ContainerId;
+import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.packet.*;
 import com.nukkitx.math.vector.Vector3f;
 import main.com.pyratron.pugmatt.bedrockconnect.gui.UIComponents;
@@ -145,7 +146,7 @@ public class PipePlayer {
         startGamePacket.setWorldTemplateOptionLocked(false);
 
         //startGamePacket.setOnlySpawningV1Villagers(false);
-        //startGamePacket.setMovementServerAuthoritative(false);
+        startGamePacket.setAuthoritativeMovementMode(AuthoritativeMovementMode.CLIENT);
         //startGamePacket.setTrial(false);
         startGamePacket.setVanillaVersion("*");
 
@@ -160,6 +161,11 @@ public class PipePlayer {
         startGamePacket.setBlockPalette(BedrockConnect.paletteManager.CACHED_PALLETE);
 
         session.sendPacket(startGamePacket);
+
+        // Required to be sent for 1.16.100
+        CreativeContentPacket creativeContentPacket = new CreativeContentPacket();
+        creativeContentPacket.setContents(new ItemData[0]);
+        session.sendPacket(creativeContentPacket);
 
         spawn();
     }

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Server.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Server.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.nukkitx.protocol.bedrock.*;
 import com.nukkitx.protocol.bedrock.v408.Bedrock_v408;
+import com.nukkitx.protocol.bedrock.v419.Bedrock_v419;
 import main.com.pyratron.pugmatt.bedrockconnect.listeners.PacketHandler;
 import main.com.pyratron.pugmatt.bedrockconnect.sql.Data;
 
@@ -74,7 +75,7 @@ public class Server {
         players = new ArrayList<>();
 
         InetSocketAddress bindAddress = new InetSocketAddress("0.0.0.0", Integer.parseInt(port));
-        codec = Bedrock_v408.V408_CODEC;
+        codec = Bedrock_v419.V419_CODEC;
         server = new BedrockServer(bindAddress);
         pong = new BedrockPong();
         pong.setEdition("MCPE");


### PR DESCRIPTION
- StartGamePacket requires AuthoratativeMovementMode to be sent; otherwise a NPE is thrown
- CreativeContentPacket must be sent now, or else the client crashes.