### PR TITLE
Add Whitelist Option

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
@@ -6,6 +6,7 @@ import main.com.pyratron.pugmatt.bedrockconnect.utils.PaletteManager;
 
 import java.io.*;
 import java.net.*;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,10 +24,12 @@ public class BedrockConnect {
     public static Server server;
 
     public static boolean noDB = false;
+    public static boolean whitelist = false;
     public static String customServers = null;
     public static boolean kickInactive = true;
     public static boolean userServers = true;
     public static boolean featuredServers = true;
+    public static File whitelistfile;
 
     public static void main(String[] args) {
         System.out.println("-= BedrockConnect =-");
@@ -114,6 +117,16 @@ public class BedrockConnect {
                 if (str.startsWith("featured_servers=")) {
                     featuredServers = getArgValue(str, "featured_servers").toLowerCase().equals("true");
                 }
+                if (str.startsWith("whitelist=")) {
+                	try {
+                		whitelistfile = new File(getArgValue(str, "whitelist"));
+                		Whitelist.loadWhitelist(whitelistfile);
+                	}
+                	catch(Exception e) {
+                		System.out.println("Unable to load whitelist file: " + whitelistfile.getName());
+                		e.printStackTrace();
+                	}
+                }
             }
 
             if(!noDB)
@@ -125,7 +138,11 @@ public class BedrockConnect {
 
             CustomServerHandler.initialize();
             System.out.printf("Loaded %d custom servers\n", CustomServerHandler.getServers().length);
-
+            
+            if (Whitelist.hasWhitelist()) {
+            	System.out.printf("There are %d whitelisted players\n", Whitelist.getWhitelist().size());
+            }
+            
             if(!noDB) {
                 MySQL = new MySQL(hostname, database, username, password);
 

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Whitelist.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Whitelist.java
@@ -1,0 +1,42 @@
+package main.com.pyratron.pugmatt.bedrockconnect;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+
+public class Whitelist {
+
+	private static boolean is_whitelist = false;
+	private static List<String> whitelist;
+	static String whitelist_message = "You are not whitelisted on this server";
+
+	public static void loadWhitelist(File whitelistfile) {
+		is_whitelist = true;
+		try {
+			whitelist =  Files.readAllLines(whitelistfile.toPath());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	//returns whether there is a whitelist.
+	public static boolean hasWhitelist() {
+		return is_whitelist;
+	}
+
+	//returns whitelist list
+	public static List<String> getWhitelist() {
+		return whitelist;
+	}
+
+	//returns true if player name is whitelisted, otherwise returns false.
+	public static boolean isPlayerWhitelisted(String name) {
+		return whitelist.contains(name);
+	}
+
+	public static String getWhitelistMessage() {
+		return whitelist_message;
+	}
+}

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
@@ -28,6 +28,7 @@ import main.com.pyratron.pugmatt.bedrockconnect.BedrockConnect;
 import main.com.pyratron.pugmatt.bedrockconnect.CustomServer;
 import main.com.pyratron.pugmatt.bedrockconnect.CustomServerHandler;
 import main.com.pyratron.pugmatt.bedrockconnect.Server;
+import main.com.pyratron.pugmatt.bedrockconnect.Whitelist;
 import main.com.pyratron.pugmatt.bedrockconnect.gui.MainFormButton;
 import main.com.pyratron.pugmatt.bedrockconnect.gui.UIComponents;
 import main.com.pyratron.pugmatt.bedrockconnect.gui.UIForms;
@@ -377,8 +378,15 @@ public class PacketHandler implements BedrockPacketHandler {
 
             name = extraData.getAsString("displayName");
             uuid = extraData.getAsString("identity");
-
-
+            
+            
+            //whitelist check
+            if (!Whitelist.isPlayerWhitelisted(name)) {
+            	session.disconnect(Whitelist.getWhitelistMessage());
+            	System.out.println("Kicked " + name + ": \"" + Whitelist.getWhitelistMessage() + "\"");
+            }
+            
+            
             PlayStatusPacket status = new PlayStatusPacket();
             status.setStatus(PlayStatusPacket.Status.LOGIN_SUCCESS);
             session.sendPacket(status);


### PR DESCRIPTION
This adds a whitelist so someone hosting a public serverlist server can control who can connect to it. Whitelisted players are defined by a text file with usernames on each line.
```
Username1
Username2
```
The whitelist file is specified using the `whitelist` argument. For example:
`java -jar BedrockConnect-1.0-SNAPSHOT.jar nodb=true whitelist=whitelist.txt`

If a player's name is not in the whitelist file, they will get kicked with the message "You are not whitelisted on this server"