### PR TITLE
1.17 support

### DIFF
--- a/serverlist-server/pom.xml
+++ b/serverlist-server/pom.xml
@@ -87,8 +87,8 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
-            <artifactId>bedrock-v431</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
+            <artifactId>bedrock-v440</artifactId>
+            <version>2.8.0-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BCPlayer.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BCPlayer.java
@@ -225,6 +225,7 @@ public class BCPlayer {
         startGamePacket.setCurrentTick(0);
         startGamePacket.setEnchantmentSeed(0);
         startGamePacket.setMultiplayerCorrelationId("");
+        startGamePacket.setServerEngine("");
 
         startGamePacket.setBlockPalette(BedrockConnect.paletteManager.CACHED_PALLETE);
 

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
@@ -5,6 +5,7 @@ import com.nukkitx.protocol.bedrock.v419.Bedrock_v419;
 import com.nukkitx.protocol.bedrock.v422.Bedrock_v422;
 import com.nukkitx.protocol.bedrock.v428.Bedrock_v428;
 import com.nukkitx.protocol.bedrock.v431.Bedrock_v431;
+import com.nukkitx.protocol.bedrock.v440.Bedrock_v440;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +16,7 @@ public class BedrockProtocol {
     /**
      * Latest available version
      */
-    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v428.V428_CODEC;
+    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v431.V431_CODEC;
 
     /**
      * A list of all supported Bedrock versions that can join BedrockConnect
@@ -29,8 +30,9 @@ public class BedrockProtocol {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v422.V422_CODEC.toBuilder()
                 .minecraftVersion("1.16.200/1.16.201")
                 .build());
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v428.V428_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(DEFAULT_BEDROCK_CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.V431_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.V440_CODEC);
     }
 
     /**


### PR DESCRIPTION
Supports 1.17 and doesn't drop compatibility for any older version.

If this could be merged and deployed before June 8th, that would really help us out. Thanks!!