### PR TITLE
Added Support For Pixel Paradise (I think)

### DIFF
--- a/legacy/index.js
+++ b/legacy/index.js
@@ -12,7 +12,7 @@ const db = async (function() {
 	
 	jack.listen(); // it listens on the standard DNS port of 53 per default
 	
-	jack.route(['mco.mineplex.com', 'hivebedrock.network', 'play.inpvp.net', 'mco.lbsg.net', 'mco.cubecraft.net'], function(data, callback) {
+	jack.route(['mco.mineplex.com', 'hivebedrock.network', 'play.inpvp.net', 'mco.lbsg.net', 'mco.cubecraft.net', 'play.pixelparadise.gg'], function(data, callback) {
 		
 		database.Server.findOne({ 
 			where: {

--- a/scripts/install-bind.sh
+++ b/scripts/install-bind.sh
@@ -115,6 +115,7 @@ add_domain inpvp.net play
 add_domain lbsg.net mco
 add_domain cubecraft.net mco
 add_domain galaxite.net play
+add_domain pixelparadise.gg play
 
 # Reload config
 


### PR DESCRIPTION
Pixel Paradise has come on to the featured servers list. Now, I don't know if my edits have actually made a difference but I'm fairly certain as I could not find anymore references of the server list.

I could not check because of the limitations of how our home infrastructure is configured. If I configured my router I possibly could but I don't want to interfere with the internet access as of right now. 

I hope my small edits helped!
