### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/raspberry-pi/Dockerfile
+++ b/docker/raspberry-pi/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/openjdk:8
+FROM openjdk:8
 RUN mkdir /brc
 ADD https://github.com/Pugmatt/BedrockConnect/releases/latest/download/BedrockConnect-1.0-SNAPSHOT.jar /brc
 WORKDIR /brc


### PR DESCRIPTION
Removed the hard coded ARM32 reference to enable 64bit OS to pull the correct image. Fixes #264 