### PR TITLE
Support Bedrock 1.18.10

### DIFF
--- a/serverlist-server/pom.xml
+++ b/serverlist-server/pom.xml
@@ -87,8 +87,8 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
-            <artifactId>bedrock-v475</artifactId>
-            <version>2.9.4-SNAPSHOT</version>
+            <artifactId>bedrock-v486</artifactId>
+            <version>2.9.5-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
@@ -10,6 +10,7 @@ import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
 import com.nukkitx.protocol.bedrock.v465.Bedrock_v465;
 import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
 import com.nukkitx.protocol.bedrock.v475.Bedrock_v475;
+import com.nukkitx.protocol.bedrock.v486.Bedrock_v486;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class BedrockProtocol {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.V465_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.V471_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v475.V475_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v486.V486_CODEC);
     }
 
     /**


### PR DESCRIPTION
Do note that transfer packets are broken in the betas, but this will allegedly be addressed before 1.18.10 releases.