### PR TITLE
Option to bind to specified IP.

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
@@ -4,13 +4,11 @@ import main.com.pyratron.pugmatt.bedrockconnect.config.Language;
 import main.com.pyratron.pugmatt.bedrockconnect.sql.Data;
 import main.com.pyratron.pugmatt.bedrockconnect.sql.MySQL;
 import main.com.pyratron.pugmatt.bedrockconnect.utils.PaletteManager;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
 import java.io.*;
 import java.net.*;
-import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -50,6 +48,7 @@ public class BedrockConnect {
             String username = "root";
             String password = "";
             String port = "19132";
+            String bindIp = "0.0.0.0";
 
             String serverLimit = "100";
 
@@ -144,6 +143,9 @@ public class BedrockConnect {
                 if (str.startsWith("language=")) {
                     languageFile = getArgValue(str, "language");
                 }
+              	if (str.startsWith("bindip=")) {
+              	    bindIp = getArgValue(str, "bindip");
+              	}
             }
 
             if(!noDB)
@@ -155,7 +157,7 @@ public class BedrockConnect {
 
             CustomServerHandler.initialize();
             System.out.printf("Loaded %d custom servers\n", CustomServerHandler.getServers().length);
-            
+
             if (Whitelist.hasWhitelist()) {
             	System.out.printf("There are %d whitelisted players\n", Whitelist.getWhitelist().size());
             }
@@ -199,7 +201,7 @@ public class BedrockConnect {
                     e.printStackTrace();
                 }
             }
-            
+
             if(!noDB) {
                 MySQL = new MySQL(hostname, database, username, password);
 
@@ -251,7 +253,7 @@ public class BedrockConnect {
                 timer.scheduleAtFixedRate(task, 0L, 1200L);
             }
 
-            server = new Server(port);
+            server = new Server(bindIp, port);
         } catch(Exception e) {
             e.printStackTrace();
         }

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Server.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/Server.java
@@ -45,11 +45,11 @@ public class Server {
     }
 
 
-    public Server(String port) {
+    public Server(String bindIp, String port) {
         Server current = this;
         players = new ArrayList<>();
 
-        InetSocketAddress bindAddress = new InetSocketAddress("0.0.0.0", Integer.parseInt(port));
+        InetSocketAddress bindAddress = new InetSocketAddress(bindIp, Integer.parseInt(port));
 
         server = new BedrockServer(bindAddress);
         pong = new BedrockPong();
@@ -80,7 +80,7 @@ public class Server {
         });
         // Start server up
         server.bind().join();
-        System.out.println("Bedrock Connection Started: 0.0.0.0:19132");
+        System.out.println("Bedrock Connection Started: " + bindIp + ":" + port);
         if(BedrockConnect.kickInactive) {
             Timer timer = new Timer();
             TimerTask task = new TimerTask() {
@@ -96,8 +96,9 @@ public class Server {
 
         new Thread() {
             public void run() {
+                Scanner sc = null;
                 try {
-                    Scanner sc = new Scanner(System.in);
+                    sc = new Scanner(System.in);
                     while(sc.hasNextLine()) {
                         String cmd = sc.next();
                         switch(cmd) {
@@ -109,6 +110,15 @@ public class Server {
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
+                } finally {
+                    if (sc != null) {
+                        try {
+                            sc.close();
+                        } catch (Exception e1) {
+                            // just ignore it
+                        }
+                        sc = null;
+                    }
                 }
             }
         }.start();


### PR DESCRIPTION
Allows to configure both server with BedrockConnect on the same machine.

I see some questions about operate server with Geyser on the same machine as BedrockConnect. This patch allows it.
Simple guide:
- create new virtual network device using IP aliasing
- in Bind all MC services must point to this new IP
- start BedrockConnect with parameter "bindip=[IP alias of new virtual device]"

If used without parameter bindip, the service is running on default device (means all - ip 0.0.0.0).