### PR TITLE
secure install script

### DIFF
--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -33,10 +33,8 @@ fi
 
 $ADDUSER \
    --system \
-   --shell /bin/bash \
+   --shell /usr/sbin/nologin \
    --user-group \
-   --password "$(dd bs=36 count=1 if=/dev/urandom 2>/dev/null | base64)" \
-   --home /home/mcbc \
    --create-home \
    mcbc
 


### PR DESCRIPTION
Fix security concern raised in issue #308 

If you still want to use the shell with the mcbc user you can always do it with root or sudo using `su -s /bin/bash mcbc`.