### PR TITLE
Update 1.19.60

### DIFF
--- a/serverlist-server/pom.xml
+++ b/serverlist-server/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
-            <artifactId>bedrock-v560</artifactId>
-            <version>2.9.15-SNAPSHOT</version>
+            <artifactId>bedrock-v567</artifactId>
+            <version>2.9.16-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/utils/BedrockProtocol.java
@@ -18,6 +18,7 @@ import com.nukkitx.protocol.bedrock.v544.Bedrock_v544;
 import com.nukkitx.protocol.bedrock.v554.Bedrock_v554;
 import com.nukkitx.protocol.bedrock.v557.Bedrock_v557;
 import com.nukkitx.protocol.bedrock.v560.Bedrock_v560;
+import com.nukkitx.protocol.bedrock.v567.Bedrock_v567;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +65,7 @@ public class BedrockProtocol {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v554.V554_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v557.V557_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v560.V560_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v567.V567_CODEC);
 
     }
 


### PR DESCRIPTION
Does not include supportedVersion in Github assets to keep workflow checking for the publication of the update