### PR TITLE
Fix connectivity to CubeCraft Games - Use Bedrock specific domain.

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
@@ -154,7 +154,7 @@ public class PacketHandler implements BedrockPacketHandler {
                                         transfer(getIP("mco.mineplex.com"), 19132);
                                         break;
                                     case 2: // Cubecraft
-                                        transfer("play.cubecraft.net", 19132);
+                                        transfer("mco.cubecraft.net", 19132);
                                         break;
                                     case 3: // Lifeboat
                                         transfer(getIP("mco.lbsg.net"), 19132);


### PR DESCRIPTION
Due to the Java soft launch of the 1.19 release on CubeCraft, the Java oriented play.cubecraft.net domain is not able to correctly handle Bedrock players joining until our full release of 1.19 across both Java and Bedrock is complete.

Under normal operations, play.cubecraft.net would allow a bedrock player to connect, as a side effect of our proxy servers working with both protocols at the same time, however we do not maintain that as a guarantee, such as in this case. 

Switching to sending the user to our bedrock oriented domain, mco.cubecraft.net resolves this issue, as that is set up to send the user to the correct server. 

We're seeing quite a few reports of users being affected by this issue, and a fairly substantial volume of users failing to connect to play.cubecraft.net with a bedrock client every minute. It would be ideal if this change could make it to your production infrastructure as soon as possible as a result. 

If you have any trouble with this PR, let me know. You are welcome to also get in touch via Discord- I'm marcoslater#0001 :)