### PR TITLE
Fix joining cubecraft

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/BedrockConnect.java
@@ -176,6 +176,7 @@ public class BedrockConnect {
                     if (ipFile.createNewFile()) {
                         featuredServerIps.put("hivebedrock.network", "167.114.81.89");
                         featuredServerIps.put("mco.mineplex.com", "108.178.12.125");
+                        featuredServerIps.put("mco.cubecraft.net", "51.178.75.10");
                         featuredServerIps.put("mco.lbsg.net", "142.44.240.96");
                         featuredServerIps.put("play.inpvp.net", "52.234.130.241");
                         featuredServerIps.put("play.galaxite.net", "51.222.8.223");

--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/listeners/PacketHandler.java
@@ -154,7 +154,7 @@ public class PacketHandler implements BedrockPacketHandler {
                                         transfer(getIP("mco.mineplex.com"), 19132);
                                         break;
                                     case 2: // Cubecraft
-                                        transfer("mco.cubecraft.net", 19132);
+                                        transfer(getIP("mco.cubecraft.net"), 19132);
                                         break;
                                     case 3: // Lifeboat
                                         transfer(getIP("mco.lbsg.net"), 19132);


### PR DESCRIPTION
#391 basically had a small oversight that `mco.cubecraft.net` is configured to be [overwritten by the DNS server](https://github.com/Pugmatt/BedrockConnect#using-your-own-dns-server), which literally will take users back to BedrockConnect. 

I will just basically apply the same thing i did back in Dec 2021 with constantly changing IP adresses being hardcoded