### PR TITLE
Allow the use of underscores in server hostnames (fix #439)

### DIFF
--- a/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/gui/UIComponents.java
+++ b/serverlist-server/src/main/com/pyratron/pugmatt/bedrockconnect/gui/UIComponents.java
@@ -132,7 +132,7 @@ public class UIComponents {
             player.createError(BedrockConnect.language.getWording("error", "portLarge"));
         else if(name.length() >= 36)
             player.createError(BedrockConnect.language.getWording("error", "nameLarge"));
-        else if (!address.matches("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$") && !address.matches("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,64}$"))
+        else if (!address.matches("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$") && !address.matches("^((?!-)[A-Za-z0-9_-]{1,63}(?<!-)\\.)+[A-Za-z]{2,64}$"))
             player.createError(BedrockConnect.language.getWording("error", "invalidAddress"));
         else if (!port.matches("[0-9]+"))
             player.createError(BedrockConnect.language.getWording("error", "invalidPort"));


### PR DESCRIPTION
This pull request updates the regex used to validate server hostnames to allow the use of underscores. 

See issue #439 for details