### PR TITLE
remove public server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ There are multiple BedrockConnect serverlist servers available that can be used,
 | IP Address | Location | Maintainer | Note |
 | ------------- | ------------- | ------------- | ------------- |
 | 104.238.130.180 | <img src="https://flagicons.lipis.dev/flags/4x3/us.svg" height="20"> | [Pugmatt](https://github.com/Pugmatt) | Main instance. Multiple load balanced servers. Might be blocked on PS4, try another instance if you experience issues. |
-| 173.82.100.84 | <img src="https://flagicons.lipis.dev/flags/4x3/us.svg" height="20"> | [jdextraze](https://github.com/jdextraze) | |
 | 207.244.229.200 | <img src="https://flagicons.lipis.dev/flags/4x3/us.svg" height="20"> | [AdamAtomus](https://github.com/adamatomus) | Located in Central US |
 | 213.171.211.142 | <img src="https://flagicons.lipis.dev/flags/4x3/gb.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) | No DNS service, only BedrockConnect server  |
 | 217.160.58.93 | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) | No DNS service, only BedrockConnect server |


### PR DESCRIPTION
My provider datacenter has informed them of an IPv4 re-numbering process that will result in a change of my VPS IPv4 addresses. I've decided to discontinue my service with them and will be taking my public Bedrock Connect instance down on November 29th, 2023.