### PR TITLE
Update DNS names of featured servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ In the case where you want to use your own DNS server instead of the one I suppl
 | The Hive | hivebedrock.network  | 104.238.130.180  |
 | Mineville | play.inpvp.net | 104.238.130.180  |
 | Lifeboat | mco.lbsg.net | 104.238.130.180  |
-| Galaxite | play.galaxite.net | 104.238.130.180 |
+| GALAXITE | play.galaxite.net | 104.238.130.180 |
+| CubeCraft | mco.cubecraft.net | 104.238.130.180 |
 
 *104.238.130.180 is the IP to the BedrockConnect serverlist server. If you are hosting your own BedrockConnect serverlist server as well, obviously use that IP instead*
 


### PR DESCRIPTION
This updates the table in the "Using your own DNS server" section.
Specifically:
1. Add CubeCraft (Apparently a new featured server)
2. Fix capitalization for GALAXITE to match what it says on the console.