### PR TITLE
Update README.md to add CubeCraft to the custom DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ In the case where you want to use your own DNS server instead of the one I suppl
 | Mineville | play.inpvp.net | 104.238.130.180  |
 | Lifeboat | mco.lbsg.net | 104.238.130.180  |
 | Galaxite | play.galaxite.net | 104.238.130.180 |
+| CubeCraft| mco.cubecraft.net | 104.238.130.180 |
 
 *104.238.130.180 is the IP to the BedrockConnect serverlist server. If you are hosting your own BedrockConnect serverlist server as well, obviously use that IP instead*
 


### PR DESCRIPTION
Updated README.md to include the domain used for CubeCraft servers, in the "Using your own DNS server" section.
Added the domain to my own DNS server and can confirm that it worked on my PC and Nintendo Switch.