### PR TITLE
Update README.md Public Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ There are multiple BedrockConnect serverlist servers available hosted by the com
 | 217.160.58.93 | N/A | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) | No DNS service, only BedrockConnect server |
 | 134.255.231.119 | N/A | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [ZAP-Hosting](https://github.com/zaphosting) |  |
 | 185.169.180.190 | N/A | <img src="https://flagicons.lipis.dev/flags/4x3/tr.svg" height="20"> | [hasankayra04](https://github.com/hasankayra04) | Dns service with NextDNS [Status Page](https://status.hasankayra04.com) (Listed as "Dns Listener") |
+| 2.59.252.99 | N/A | <img src="https://flagicons.lipis.dev/flags/4x3/kr.svg" height="20"> | [Minjae](https://github.com/minj-ae) | Located in Seoul, South Korea. No DNS service, only BedrockConnect server |
 </details>
 
 


### PR DESCRIPTION
Added a new BedrockConnect server located in Seoul, South Korea.
This adds the first BedrockConnect server in South Korea, improving accessibility for players in the Asia-Pacific region.