### PR TITLE
Change DNS service description for HasanBC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ There are multiple BedrockConnect instances available hosted by the community av
 | 104.238.130.180 | ✔️ | BCMain, BCMain1, BCMain2, BCMain3, BCMain4 | <img src="https://flagicons.lipis.dev/flags/4x3/us.svg" height="20"> | [Pugmatt](https://github.com/Pugmatt) | Main instance. Multiple load balanced servers. If issues occur on PS4/PS5 with DNS method, replace primary DNS address with 45.55.68.52 |
 | 5.161.83.73 | | Cybrancee | <img src="https://flagicons.lipis.dev/flags/4x3/us.svg" height="20"> | [Cybrancee](https://github.com/cybrancee) |  Located in Virginia, United States  |
 | 134.255.231.119 | ✔️ | | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [ZAP-Hosting](https://github.com/zaphosting) |  |
-| 185.169.180.190 | ✔️ | HasanBC1 | <img src="https://flagicons.lipis.dev/flags/4x3/tr.svg" height="20"> | [hasankayra04](https://github.com/hasankayra04) | DNS service with NextDNS [Status Page](https://status.hasankayra04.com) (Listed as "Dns Listener") |
+| 185.169.180.190 | ✔️ | HasanBC1 | <img src="https://flagicons.lipis.dev/flags/4x3/tr.svg" height="20"> | [hasankayra04](https://github.com/hasankayra04) | DNS service with NextDNS [Status Page](https://status.hasankayra04.com) (Listed as "Dns Resolver") |
 | 213.171.211.142 | | | <img src="https://flagicons.lipis.dev/flags/4x3/gb.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) |  |
 | 217.160.58.93 | | | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) | |
 | 2.59.252.99 | | | <img src="https://flagicons.lipis.dev/flags/4x3/kr.svg" height="20"> | [Minjae](https://github.com/minj-ae) | Located in Seoul, South Korea |


### PR DESCRIPTION
Updated the description of the DNS service for HasanBC1.

I moved to Uptime Kuma, so name of the monitor changed.