### PR TITLE
Add bedrock connect public instance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ There are multiple BedrockConnect instances available hosted by the community av
 | 213.171.211.142 | | <img src="https://flagicons.lipis.dev/flags/4x3/gb.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) |  |
 | 217.160.58.93 | | <img src="https://flagicons.lipis.dev/flags/4x3/de.svg" height="20"> | [kmpoppe](https://github.com/kmpoppe) | |
 | 2.59.252.99 | | <img src="https://flagicons.lipis.dev/flags/4x3/kr.svg" height="20"> | [Minjae](https://github.com/minj-ae) | Located in Seoul, South Korea |
+| 57.128.153.204 | ✔️ | <img src="https://flagicons.lipis.dev/flags/4x3/gb.svg" height="20"> | [AdrianJoeK](https://github.com/AdrianJoeK) | UK instance. DNS method enabled. |
 </details>
 
 


### PR DESCRIPTION
Hi, this is a BedrockConnect instance which also has the DNS method enabled.
User added servers and featured servers are enabled.
It also includes one custom server which I own, this is there for our players to be able to connect easier, however I am more than happy to remove it if you prefer public-listed instances to remain neutral.